### PR TITLE
Update Generation.pm: Add style and quality parameters for dall-e-3 model

### DIFF
--- a/lib/OpenAI/API/Request/Image/Generation.pm
+++ b/lib/OpenAI/API/Request/Image/Generation.pm
@@ -14,7 +14,7 @@ extends 'OpenAI::API::Request';
 has prompt => ( is => 'ro', isa => Str, required => 1, );
 
 has n               => ( is => 'ro', isa => Int, );
-has size            => ( is => 'ro', isa => Enum [ '256x256', '512x512', '1024x1024' ], );
+has size            => ( is => 'ro', isa => Enum [ '256x256', '512x512', '1024x1024', '1024x1792', '1792x1024' ], );
 has quality         => ( is => 'ro', isa => Enum [ 'standard', 'hd' ], );
 has style           => ( is => 'ro', isa => Enum [ 'vivid', 'natural' ], );
 has response_format => ( is => 'ro', isa => Enum [ 'url',     'b64_json' ], );

--- a/lib/OpenAI/API/Request/Image/Generation.pm
+++ b/lib/OpenAI/API/Request/Image/Generation.pm
@@ -18,6 +18,8 @@ has size            => ( is => 'ro', isa => Enum [ '256x256', '512x512', '1024x1
 has quality         => ( is => 'ro', isa => Enum [ 'standard', 'hd' ], );
 has style           => ( is => 'ro', isa => Enum [ 'vivid', 'natural' ], );
 has response_format => ( is => 'ro', isa => Enum [ 'url',     'b64_json' ], );
+has model           => ( is => 'ro', isa => Enum [ 'dall-e-2', 'dall-e-3' ], );
+
 has user            => ( is => 'ro', isa => Str, );
 
 sub endpoint { 'images/generations' }

--- a/lib/OpenAI/API/Request/Image/Generation.pm
+++ b/lib/OpenAI/API/Request/Image/Generation.pm
@@ -15,6 +15,8 @@ has prompt => ( is => 'ro', isa => Str, required => 1, );
 
 has n               => ( is => 'ro', isa => Int, );
 has size            => ( is => 'ro', isa => Enum [ '256x256', '512x512', '1024x1024' ], );
+has quality         => ( is => 'ro', isa => Enum [ 'standard', 'hd' ], );
+has style           => ( is => 'ro', isa => Enum [ 'vivid', 'natural' ], );
 has response_format => ( is => 'ro', isa => Enum [ 'url',     'b64_json' ], );
 has user            => ( is => 'ro', isa => Str, );
 


### PR DESCRIPTION
https://help.openai.com/en/articles/8555480-dall-e-3-api

dall-e-3 model is now available via API and it adds the parameters `quality` and `style`. When using the 3 model, `n` is currently limited to `1`, however I'm not checking for that in this PR so keep that in mind.