### PR TITLE
Mark deprecated in favor of OpenAPI::Client::OpenAI

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for OpenAI-API
 
+0.38    2024-05-17
+		Mark as deprecated in favor of OpenAPI::Client::OpenAI
+
 0.37    2023-04-09
         Replace AnyEvent with IO::Async::Loop
         Replace Promises with IO::Async::Future

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -42,6 +42,7 @@ my %WriteMakefileArgs = (
                 web => 'https://github.com/nferraz/perl-openai-api/issues',
             },
         },
+        x_deprecated => 1,
     },
     dist  => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean => { FILES    => 'OpenAI-API-*' },

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ OpenAI::API - Perl interface to OpenAI API
 
 # VERSION
 
-0.37
+0.38
 
 # SYNOPSIS
 
@@ -26,6 +26,9 @@ OpenAI::API - Perl interface to OpenAI API
     my $message = $res->{choices}[0]{message};    # or simply: my $message = "$res";
 
 # DESCRIPTION
+
+This module is deprecated in favor of
+[OpenAPI::Client::OpenAI](https://metacpan.org/pod/OpenAPI::Client::OpenAI).
 
 OpenAI::API is a Perl module that provides an interface to the OpenAI API,
 which allows you to generate text, translate languages, summarize text,

--- a/lib/OpenAI/API.pm
+++ b/lib/OpenAI/API.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use OpenAI::API::Config;
 
-our $VERSION = 0.37;
+our $VERSION = 0.38;
 
 BEGIN {
     my %module_dispatcher = (
@@ -84,6 +84,8 @@ OpenAI::API - Perl interface to OpenAI API
     my $message = $res->{choices}[0]{message};    # or simply: my $message = "$res";
 
 =head1 DESCRIPTION
+
+This module is deprecated in favor of L<OpenAPI::Client::OpenAI>.
 
 OpenAI::API is a Perl module that provides an interface to the OpenAI API,
 which allows you to generate text, translate languages, summarize text,


### PR DESCRIPTION
This PR marks this module as deprecated. No functional change.

You can see an example of the result at [this CPAN module](https://metacpan.org/pod/OpenSky::API).